### PR TITLE
Allow publishing only the executable name rather than the complete path

### DIFF
--- a/config.ini.example
+++ b/config.ini.example
@@ -6,3 +6,4 @@ port = 1883
 user = your_username
 password = your_password
 path = windows_webcam_monitor/used_by
+publishFullPath = yes

--- a/service.py
+++ b/service.py
@@ -23,6 +23,9 @@ def webcam_used_by():
     
     return None
 
+def get_executable_name_from_path(path):
+    return path.split("#")[-1]
+
 if __name__ == '__main__':
     config = configparser.ConfigParser()
     config.read('config.ini')
@@ -34,6 +37,8 @@ if __name__ == '__main__':
     while True:
         used_by = webcam_used_by()
         if used_by != None:
+            if config['mqtt'].getboolean('publishFullPath') == False:
+                used_by = get_executable_name_from_path(used_by)
             client.publish(config['mqtt']['path'], used_by)
         else:
             client.publish(config['mqtt']['path'], 'off')


### PR DESCRIPTION
For me it doesn't matter if the cam is currently used by Discord in the folder `app-0.0308` or `app-0.0309` (as an example).

This PR makes the MQTT publishing configurable. Default is the same behavior as before (full path is published). Even without adding the new config parameter, the behavior is unchanged -> no impact on existing installs (of busy people 😘)